### PR TITLE
bugFix/Stop jump to create page

### DIFF
--- a/client/components/Main.jsx
+++ b/client/components/Main.jsx
@@ -98,6 +98,7 @@ class Main extends React.Component {
 
         self.setState({
           currentTournamentGames: games,
+          currentGame: games[0],
           inProgress: true
         });
 

--- a/server/index.js
+++ b/server/index.js
@@ -149,7 +149,7 @@ routes.put('/api/games', function(req, res) {
     .then(function(response) {
       res.status(202).send('Successfully Updated Game Score')
     }).catch(function(err) {
-      res.status(500).send(err)
+      res.status(500).send('Failed to update scores in databse', err)
     })
 })
   


### PR DESCRIPTION
When a tournament is created sets currentGame to first game in the list. This resolves the issue where if no game was selected as current game and scores were input into the GameStatsForm it would jump back to the create tournament page and you would lose your progress. 

Still able to click on other games to set them as the current game.