### PR TITLE
Bugfix/show players in correct list return from stats view

### DIFF
--- a/client/components/AddPlayerForm.jsx
+++ b/client/components/AddPlayerForm.jsx
@@ -42,7 +42,7 @@ class Form extends React.Component {
     if (this.state.noError) {
       return (
 
-        <form className="form-inline" onSubmit={this.addNewPlayer.bind(this)}>
+        <form className="form-inline" onSubmit={this.addNewPlayer.bind(this)} autoComplete="off">
           <div className="form-group">
             <input type="text"
               className="form-control user-form"

--- a/client/components/Main.jsx
+++ b/client/components/Main.jsx
@@ -177,8 +177,15 @@ class Main extends React.Component {
   }
 
   toggleStatsView() {
+    var self = this;
     this.setState({
-      statsView: !this.state.statsView
+      statsView: !this.state.statsView,
+      tourneyPlayersList: []
+    });
+    utils.getAllPlayers(this.state).then(res => {
+      self.setState({
+        allPlayersList: res
+      });
     });
   }
 

--- a/client/components/Main.jsx
+++ b/client/components/Main.jsx
@@ -187,6 +187,11 @@ class Main extends React.Component {
         allPlayersList: res
       });
     });
+    utils.getOngoingTournaments().then(function(tourneys) {
+      self.setState({
+        ongoingTournamentsList: tourneys.data
+      });
+    });
   }
 
   resetTournament() {

--- a/server/index.js
+++ b/server/index.js
@@ -12,7 +12,8 @@ var knex = require('knex')({
   client: 'sqlite3',
   connection: {
     filename: './database.sqlite3'
-  }
+  },
+  useNullAsDefault: true
 });
 
 //

--- a/server/serverHelpers.js
+++ b/server/serverHelpers.js
@@ -2,7 +2,8 @@ var knex = require('knex')({
   client: 'sqlite3',
   connection: {
     filename: './database.sqlite3'
-  }
+  },
+  useNullAsDefault: true
 });
 
 exports.createGamesForTourney = function(tourneyId, playersInTourneyList) {


### PR DESCRIPTION
When returning to home page from StatsView it will now show the players in database back in the add player to tournament list instead of listed under create new tournament. 

Also shows all current tournaments in progress when returning to home page from StatsView.

Added autoComplete = off for the Add Player form

Added useNullAsDefault: true in serverHelpers.js and server.js to hopefully fix warning we were getting on starting our server.